### PR TITLE
Update rtl_ltr_linter.py

### DIFF
--- a/scripts/rtl_ltr_linter.py
+++ b/scripts/rtl_ltr_linter.py
@@ -105,7 +105,7 @@ HTML_DIR_ATTR_RE = re.compile(r"dir\s*=\s*(['\"])(rtl|ltr)\1", re.IGNORECASE)
 SPAN_DIR_RE = re.compile(r'<span[^>]*dir=["\'](rtl|ltr)["\'][^>]*>', re.IGNORECASE)
 
 # Regex to identify inline code (text enclosed in single backticks)
-INLINE_CODE_RE = re.compile(r'^`.*`$')
+INLINE_CODE_RE = re.compile(r'`[^`]+`')
 
 # Regex to identify the start of a code block (```)
 # Can be preceded by spaces or a '>' character (for blockquotes)


### PR DESCRIPTION
## What does this PR do?
Improve repo (fix regex handling for inline code detection)

## IMPORTANT
- [] Read our [contributing guidelines](https://github.com/EbookFoundation/free-programming-books/blob/main/docs/CONTRIBUTING.md).
- [] Is this a revision of a previously submitted PR? If so, STOP! Go back, reopen the PR, and add commit(s) the branch you previously submitted. Please don't make the job of reviewing more difficult by hiding previous work.

## For resources
### Description
Fixes the INLINE_CODE_RE regex in rtl_linter.py so that inline code within text (e.g., Use the `npm install` command.) is properly detected and ignored during RTL/LTR linting.


### Why is this valuable (or not)?
Prevents false RTL/LTR warnings caused by inline code segments not being recognized, improving the accuracy of lint checks.


### How do we know it's really free?
N/A – this is a code improvement, not a content addition.

### For book lists, is it a book? For course lists, is it a course? etc.
NA

## Checklist:
- [x] [Search](https://ebookfoundation.github.io/free-programming-books-search/) for duplicates.
- [x] Include author(s) and platform where appropriate.
- [x] Put lists in alphabetical order, correct spacing.
- [x] Add needed indications (PDF, access notes, under construction).
- [x] Used an informative name for this pull request.

## Follow-up

Verified that GitHub Actions run successfully after the change
